### PR TITLE
Improved storage-device and storage-device-path on linux

### DIFF
--- a/linux.lisp
+++ b/linux.lisp
@@ -112,14 +112,11 @@
         ("/proc/self/mountinfo" "%*d %*d %*d:%*d / %s %*[^-]- %*s %s"
                                 (fail "Device not found in mountinfo table"))
       (when (= 0 (cffi:foreign-funcall "strncmp" :pointer mountpoint :string mount-root :size 32 :int))
-        (return (pathname-name
-                 (pathname-utils:parse-native-namestring
-                  (cffi:foreign-string-to-lisp name :max-chars 32)
-                  :as :file)))))))
+        (return (cffi:foreign-string-to-lisp name :max-chars 32))))))
 
 (define-implementation storage-device-path (device)
   (do-proc ((mount :char 512) (name :char 32))
-      ("/proc/self/mountinfo" "%*d %*d %*d:%*d / %s %*[^-]- %*s /dev/%s"
+      ("/proc/self/mountinfo" "%*d %*d %*d:%*d / %s %*[^-]- %*s %s"
                               (fail "Device not found in mountinfo table"))
     (when (= 0 (cffi:foreign-funcall "strncmp" :pointer name :string device :size 32 :int))
       (return (pathname-utils:parse-native-namestring

--- a/linux.lisp
+++ b/linux.lisp
@@ -56,23 +56,70 @@
              (return (values (conv idle) (conv (+ user nice system idle iowait irq softirq)))))))))))
 
 (cffi:defcstruct (stat :size 144 :conc-name stat-)
-  (dev     :uint64 :offset  0))
+  (dev     :uint64 :offset 0)
+  (mode    :uint32 :offset 24))
+
+(defun readlink (path)
+  (cffi:with-foreign-objects ((buf :char 512))
+    (let ((size (cffi:foreign-funcall "readlink" :string (pathname-utils:native-namestring path) :pointer buf :int 512 :int)))
+      (when (= size -1)
+        (fail (cffi:foreign-funcall "strerror" :int64 errno)))
+      (cffi:foreign-string-to-lisp buf :max-chars size))))
+
+(defconstant +s-ifmt+ #o170000)
+(defconstant +s-iflnk+ #o120000)
+(defun s-istype (mode mask) (= (logand mode +s-ifmt+) mask))
+(defun s-islnk (mode) (s-istype mode +s-iflnk+))
+
+(defun symlinkp (path)
+  (cffi:with-foreign-objects ((stat '(:struct stat)))
+    (when (< (cffi:foreign-funcall "lstat" :string (pathname-utils:native-namestring path) :pointer stat :int) 0)
+      (fail (cffi:foreign-funcall "strerror" :int64 errno)))
+    (s-islnk (stat-mode stat))))
+
+(defun pathname-force-file (path)
+  (cond
+    ((pathname-utils:root-p path) path)
+    ((pathname-utils:file-p path) path)
+    (t (let ((directories (pathname-directory path)))
+         (make-pathname :defaults path
+                        :directory (butlast directories)
+                        :name (car (last directories)))))))
+
+(defun find-mount-root (path)
+  (labels ((dev-id (path)
+             (cffi:with-foreign-objects ((stat '(:struct stat)))
+               (when (< (cffi:foreign-funcall "stat" :string (pathname-utils:native-namestring path) :pointer stat :int) 0)
+                 (fail (cffi:foreign-funcall "strerror" :int64 errno)))
+               (stat-dev stat)))
+           (rec (path &optional (id (dev-id path)))
+             (if (pathname-utils:root-p path)
+                 path
+                 (let* ((parent (pathname-utils:parent path))
+                        (parent-id (dev-id parent)))
+                   (if (= parent-id id)
+                       (rec parent parent-id)
+                       path)))))
+    (let* ((root (rec path))
+           (root-file (pathname-force-file root)))
+      (if (symlinkp root-file)
+          (find-mount-root (readlink root-file))
+          root))))
 
 (define-implementation storage-device (path)
-  (cffi:with-foreign-objects ((stat '(:struct stat)))
-    (when (< (cffi:foreign-funcall "stat" :string (pathname-utils:native-namestring path) :pointer stat :int) 0)
-      (fail (cffi:foreign-funcall "strerror" :int64 errno)))
-    (let ((dev (stat-dev stat)))
-      (do-proc ((l :int) (r :int) (name :char 32))
-          ("/proc/self/mountinfo" "%*d %*d %d:%d / %*[^-]- %*s /dev/%s"
-                                  (fail "Device not found in mountinfo table"))
-        (when (and (= l (ldb (byte 32 8) dev))
-                   (= r (1- (ldb (byte 8 0) dev))))
-          (return (cffi:foreign-string-to-lisp name :max-chars 32)))))))
+  (let* ((mount-root (pathname-utils:native-namestring (pathname-force-file (find-mount-root path)))))
+    (do-proc ((mountpoint :char 512) (name :char 32))
+        ("/proc/self/mountinfo" "%*d %*d %*d:%*d / %s %*[^-]- %*s %s"
+                                (fail "Device not found in mountinfo table"))
+      (when (= 0 (cffi:foreign-funcall "strncmp" :pointer mountpoint :string mount-root :size 32 :int))
+        (return (pathname-name
+                 (pathname-utils:parse-native-namestring
+                  (cffi:foreign-string-to-lisp name :max-chars 32)
+                  :as :file)))))))
 
 (define-implementation storage-device-path (device)
   (do-proc ((mount :char 512) (name :char 32))
-      ("/proc/self/mountinfo" "%*d %*d %*d:%*d / %s %*s %*s - %*s /dev/%s"
+      ("/proc/self/mountinfo" "%*d %*d %*d:%*d / %s %*[^-]- %*s /dev/%s"
                               (fail "Device not found in mountinfo table"))
     (when (= 0 (cffi:foreign-funcall "strncmp" :pointer name :string device :size 32 :int))
       (return (pathname-utils:parse-native-namestring


### PR DESCRIPTION
Resolve the storage path by traversing the filesystem upwards until the device id returned by `stat` changes to find the root of the mountpoint, handle symlink, and then compare with the mount root in `/proc/self/mountinfo`, this way it can handle complex file systems like btrfs and lvm volumes.

It returns values for actual pseudo-filesystems like /proc and /sys, maybe it shouldn't?

Changed `storage-device` to return the full path, to handle device mapper volumes like LVM for example, exists as `/dev/mapper/vg-lv` or `/dev/vg/lv`, so returning "vg-lv" might be confusing, matched the change in `storage-device-path` to search for the full path.