### PR TITLE
Add OpenGL/driver version to gpu-info

### DIFF
--- a/documentation.lisp
+++ b/documentation.lisp
@@ -447,16 +447,18 @@ See NETWORK-INFO")
   (function gpu-info
     "Returns information about the graphics card.
 
-Returns two values:
+Returns three values:
    The vendor of the graphics card as a keyword:
      :NVIDIA
      :AMD (formerly ATI)
      :INTEL
      and others
   The model of the graphics card as a string
+  The version of OpenGL and/or graphics card driver as a string
 
 If the function is unsupported,
   NIL
+  \"Unknown\"
   \"Unknown\"
 are returned.
 

--- a/opengl.lisp
+++ b/opengl.lisp
@@ -54,4 +54,5 @@
                   ((search "nvidia" vendor :test #'char-equal) :nvidia)
                   ((search "ati" vendor :test #'char-equal) :amd)
                   ((search "amd" vendor :test #'char-equal) :amd)))
-          (gl:get-string :renderer)))
+          (gl:get-string :renderer)
+          (gl:get-string :version)))

--- a/protocol.lisp
+++ b/protocol.lisp
@@ -226,8 +226,8 @@
 (define-protocol-fun process-info () (pathname pathname string string)
   (values *default-pathname-defaults* *default-pathname-defaults* "Unknown" "Unknown"))
 
-(define-protocol-fun gpu-info () (symbol string)
-  (values NIL "Unknown"))
+(define-protocol-fun gpu-info () (symbol string string)
+  (values NIL "Unknown" "Unknown"))
 
 (define-protocol-fun network-info () ((or string null))
   (values NIL))


### PR DESCRIPTION
Hey, I thought why not add the `GL_VERSION` info to output of `gpu-info`, that might come in handy in situations where you tell the users to update their video drivers 😁 