### PR TITLE
Fix machine-room for windows

### DIFF
--- a/windows.lisp
+++ b/windows.lisp
@@ -118,6 +118,11 @@
 
 (define-implementation machine-room ()
   (cffi:with-foreign-objects ((memory-status '(:struct memory-status)))
+    (setf (memory-status-length memory-status)
+          (cffi:foreign-type-size '(:struct memory-status)))
+    (windows-call "GlobalMemoryStatusEx"
+                  :pointer memory-status
+                  :bool)
     (let ((available (memory-status-available-physical memory-status))
           (total (memory-status-total-physical memory-status)))
       (values (- total available)


### PR DESCRIPTION
Hey! It would appear that `machine-room` on windows is missing the actual WinAPI call to get the data and so just returns random garbage from stack. This PR fixes it.