### PR TITLE
Fix process-room on Windows

### DIFF
--- a/windows.lisp
+++ b/windows.lisp
@@ -88,6 +88,7 @@
     (windows-call "GetProcessMemoryInfo"
                   :pointer (process)
                   :pointer memory-counters
+                  :uint32 (cffi:foreign-type-size '(:struct memory-counters))
                   :bool)
     (memory-counters-working-set-size memory-counters)))
 


### PR DESCRIPTION
Hey! Trying to call `process-room` on Windows, I'm getting "The data area passed to a system call is too small" error. I've noticed [`GetProcessMemoryInfo`](https://learn.microsoft.com/en-us/windows/win32/api/psapi/nf-psapi-getprocessmemoryinfo) call is missing the required parameter `cb`, the `PPROCESS_MEMORY_COUNTERS` structure size in bytes. This PR fixes it.