### PR TITLE
Fix compilation on MacOS

### DIFF
--- a/machine-state.asd
+++ b/machine-state.asd
@@ -14,7 +14,7 @@
                (:file "posix" :if-feature (:and (:not :openbsd)
                                                 (:or :posix :linux :darwin :bsd)))
                (:file "darwin" :if-feature :darwin)
-               (:file "bsd" :if-feature :bsd)
+               (:file "bsd" :if-feature (:and :bsd (:not :darwin)))
                (:file "freebsd" :if-feature :freebsd)
                (:file "openbsd" :if-feature :openbsd)
                (:file "linux" :if-feature :linux)


### PR DESCRIPTION
Hey again! I was trying to use `machine-state` on MacOS, but it failed to compile like that:

```
; file: /Users/runner/quicklisp/dists/lucky-lambda/software/machine-state-4557a8f244148d745eac4a91f1bcbe65f6d2640f/bsd.lisp
; in: CFFI:DEFCSTRUCT (CLOCKINFO :SIZE :CONC-NAME CLOCKINFO-)
;     (CFFI:DEFCSTRUCT (ORG.SHIRAKUMO.MACHINE-STATE::CLOCKINFO :SIZE :CONC-NAME
;                       ORG.SHIRAKUMO.MACHINE-STATE::CLOCKINFO-)
;       (ORG.SHIRAKUMO.MACHINE-STATE::HZ :INT))
; 
; caught ERROR:
;   (during macroexpansion of (CFFI:DEFCSTRUCT (CLOCKINFO :SIZE ...)
;     ...))
;   malformed property list: (:SIZE :CONC-NAME CLOCKINFO-).

; in: DEFCONSTANT +MAXCOMLEN+
;     (DEFCONSTANT ORG.SHIRAKUMO.MACHINE-STATE::+MAXCOMLEN+)
; 
; caught ERROR:
;   (during macroexpansion of (DEFCONSTANT +MAXCOMLEN+))
;   Error while parsing arguments to DEFMACRO DEFCONSTANT:
;     too few elements in
;       (+MAXCOMLEN+)
;     to satisfy lambda list
;       (NAME VALUE &OPTIONAL (DOC)):
;     between 2 and 3 expected, but got 1

; in: DEFUN FIND-MOUNT-ROOT
;     (CFFI:WITH-FOREIGN-OBJECTS ((ORG.SHIRAKUMO.MACHINE-STATE::STAT
;                                  '(:STRUCT ORG.SHIRAKUMO.MACHINE-STATE::STAT)))
;       (ORG.SHIRAKUMO.MACHINE-STATE::POSIX-CALL "stat" :STRING
;                                                (PATHNAME-UTILS:NATIVE-NAMESTRING
;                                                 ORG.SHIRAKUMO.MACHINE-STATE::PATH)
;                                                :POINTER
;                                                ORG.SHIRAKUMO.MACHINE-STATE::STAT
;                                                :INT)
;       (ORG.SHIRAKUMO.MACHINE-STATE::STAT-DEV ORG.SHIRAKUMO.MACHINE-STATE::STAT))
; 
; caught ERROR:
;   during macroexpansion of
;   (CFFI:WITH-FOREIGN-OBJECT (STAT '#)
;     (CFFI:WITH-FOREIGN-OBJECTS NIL
;       #
;       ...)).
;   Use *BREAK-ON-SIGNALS* to intercept.
;   
;    Unknown CFFI type (:STRUCT STAT)

; in: CFFI:DEFCSTRUCT (SOCKADDR-DL :SIZE :CONC-NAME SOCKADDR-DL-)
;     (CFFI:DEFCSTRUCT (ORG.SHIRAKUMO.MACHINE-STATE::SOCKADDR-DL :SIZE :CONC-NAME
;                       ORG.SHIRAKUMO.MACHINE-STATE::SOCKADDR-DL-)
;       (ORG.SHIRAKUMO.MACHINE-STATE::INTERFACE-NAME-LENGTH :UNSIGNED-CHAR :OFFSET
;        5)
;       (ORG.SHIRAKUMO.MACHINE-STATE::ADDRESS-LENGTH :UNSIGNED-CHAR :OFFSET 6)
;       (ORG.SHIRAKUMO.MACHINE-STATE::DATA (:ARRAY :UNSIGNED-CHAR) :OFFSET 8))
; 
; caught ERROR:
;   (during macroexpansion of (CFFI:DEFCSTRUCT (SOCKADDR-DL :SIZE ...)
;     ...))
;   malformed property list: (:SIZE :CONC-NAME SOCKADDR-DL-).
[package org.shirakumo.machine-state].............

; in: DEFCONSTANT +AF-INET6+
;     (DEFCONSTANT ORG.SHIRAKUMO.MACHINE-STATE::+AF-INET6+)
; 
; caught ERROR:
;   (during macroexpansion of (DEFCONSTANT +AF-INET6+))
;   Error while parsing arguments to DEFMACRO DEFCONSTANT:
;     too few elements in
;       (+AF-INET6+)
;     to satisfy lambda list
;       (NAME VALUE &OPTIONAL (DOC)):
;     between 2 and 3 expected, but got 1

; 
; caught ERROR:
;   READ error during COMPILE-FILE:
;   
;     The variable +AF-INET6+ is unbound.
;   
;     (in form starting at line: 322, column: 0, position: 11416)
```

I figure that's because MacOS considered to be a BSD system while your `bsd.lisp` is written for actual modern BSDs like FreeBSD and OpenBSD. With this PR, `machine-state` compiles and works thanks to implementations from `posix.lisp`.